### PR TITLE
initial iArduSubComms comms over ttyUSB0 to pixhawk

### DIFF
--- a/src/iArduSubComms/ArduSubComms.h
+++ b/src/iArduSubComms/ArduSubComms.h
@@ -8,6 +8,7 @@
 #ifndef ArduSubComms_HEADER
 #define ArduSubComms_HEADER
 
+#include <boost/asio.hpp>
 #include "MOOS/libMOOS/Thirdparty/AppCasting/AppCastingMOOSApp.h"
 
 class ArduSubComms : public AppCastingMOOSApp
@@ -16,13 +17,13 @@ class ArduSubComms : public AppCastingMOOSApp
    ArduSubComms();
    ~ArduSubComms();
 
- protected: // Standard MOOSApp functions to overload  
+ protected: // Standard MOOSApp functions to overload
    bool OnNewMail(MOOSMSG_LIST &NewMail);
    bool Iterate();
    bool OnConnectToServer();
    bool OnStartUp();
 
- protected: // Standard AppCastingMOOSApp function to overload 
+ protected: // Standard AppCastingMOOSApp function to overload
    bool buildReport();
 
  protected:
@@ -31,6 +32,12 @@ class ArduSubComms : public AppCastingMOOSApp
  private: // Configuration variables
 
  private: // State variables
+   std::string*                                m_mavlink_msg;
+   std::string                                 m_mavlink_port;
+   unsigned int                                m_mavlink_baud;
+   boost::asio::io_service                     m_io;
+   boost::shared_ptr<boost::asio::serial_port> m_serial;
+
 };
 
-#endif 
+#endif

--- a/src/iArduSubComms/CMakeLists.txt
+++ b/src/iArduSubComms/CMakeLists.txt
@@ -14,6 +14,7 @@ ADD_EXECUTABLE(iArduSubComms ${SRC})
 
 TARGET_LINK_LIBRARIES(iArduSubComms
    ${MOOS_LIBRARIES}
+   boost_system
    apputil
    mbutil
    m


### PR DESCRIPTION
Transferring MAVLINK_MESSAGE buffer from MOOSDB to pixhawk via /dev/ttyUSB0 - uses Boost to open port and transfer data